### PR TITLE
Update Readme, use create methods instead of new

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,21 @@ Initially this includes a weekly schedule with configurable behavior on DST chan
 
 ### Create a new scheduler
 
-    Scheduler scheduler = new Scheduler(vertx);
+    Scheduler scheduler = Scheduler.create(vertx);
 
 ### Create a time of week
 
     // Tuesday at 2:30 AM UTC
-    TimeOfWeek time1 = new TimeOfWeek(Day.TUE, 2, 30, 0, 0);
+    TimeOfWeek time1 = TimeOfWeek.create(Day.TUE, 2, 30, 0, 0);
 
     // Tuesday at 2:30 AM localtime
-    TimeOfWeek time2 = new TimeOfWeek(TimeZone.getTimeZone("America/New_York"), Day.TUE, 2, 30, 0, 0);
+    TimeOfWeek time2 = TimeOfWeek.create(TimeZone.getTimeZone("America/New_York"), Day.TUE, 2, 30, 0, 0);
 
     // Sunday at 01:01 AM UTC
-    TimeOfWeek time3 = new TimeOfWeek(60*60*1000 + 60*1000);
+    TimeOfWeek time3 = TimeOfWeek.create(60*60*1000 + 60*1000);
 
     // Sunday at 01:01 AM localtime
-    TimeOfWeek time4 = new TimeOfWeek(TimeZone.getTimeZone("America/New_York"), 60*60*1000 + 60*1000);
+    TimeOfWeek time4 = TimeOfWeek.create(TimeZone.getTimeZone("America/New_York"), 60*60*1000 + 60*1000);
 
 ### Set a one shot timer on next occurrence of time
 
@@ -61,7 +61,7 @@ Initially this includes a weekly schedule with configurable behavior on DST chan
 
 Behavior on DST changes is configurable.  Default is to skip when time changes ahead and to run both when time changes back.
 
-    TimeOfWeek time1 = new TimeOfWeek(TimeZone.getTime("America/New_York", Day.TUE, 2, 30, 0, 0, DstAheadBehavior.DST_AHEAD_SKIP, DstBackBehavior.DST_BACK_BOTH_HOURS);
+    TimeOfWeek time1 = TimeOfWeek.create(TimeZone.getTime("America/New_York", Day.TUE, 2, 30, 0, 0, DstAheadBehavior.DST_AHEAD_SKIP, DstBackBehavior.DST_BACK_BOTH_HOURS);
 
 #### Time change ahead
 The scheduler can either skip any events during the missing hour (DST_AHEAD_SKIP), or run them on the next hour (DST_AHEAD_NEXT_HOUR).


### PR DESCRIPTION
This fixes Readme. 
One should use `create` methods of `Scheduler` and `TimeOfWeek` instead of `new`
